### PR TITLE
Update composer.json. Require ">=2.0.0,<2.1.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.4",
         "mika56/spfcheck": "^2.0",
-        "purplepixie/phpdns": "^2.0"
+        "purplepixie/phpdns": ">=2.0.0,<2.1.0"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
It seems purplepixie/phpdns version 2.1.0 breaks the domain validation. If I install the current version of PHP-SPF-Check-DNS-Direct I get 2.1.0 which somehow breaks SPF check. If I run following function with 2.1.0 I get response "NO" always with valid domains. When I force 2.0.5 version everything works fine.

This happens at least on PHP 8.2.

```
	public static function validateDomain(string $domain): bool
	{
		$checker = new SPFCheck(new DNSRecordGetterDirect("1.1.1.1"));

		if ($checker->getIPStringResult('x.x.x.x', $domain) === Result::SHORT_PASS) {
			return true;
		} else {
			return false;
		}
	}
```